### PR TITLE
編集エンドポイントたちにmodeパラメータを追加

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -431,12 +431,15 @@ components:
       x-tags:
         - route
     DrawingMode:
-      title: DrawingMode
       type: string
+      title: DrawingMode
       description: |-
         `Segment`を補完するときのモード
         * `follow_road`: 道に沿う
         * `freehand`: フリーハンド
+      enum:
+        - follow_road
+        - freehand
     RouteId:
       type: string
       title: RouteId


### PR DESCRIPTION
フリーハンドモード（=> team-azb/route-bucket-backend#45）実装のために、編集系のエンドポイントに新たに`mode`というパラメータを追加したい

以下の二点について意見あれば

* 今はフリーハンドかそうじゃないかの2値なので、boolでもいいが、一応enum（jsonだとstring）にした方がいい気がしている
* クエリパラメータにするか迷ったが、以下の記事を読んでリクエストボディが適切だなという結論になった
  * https://qiita.com/sakuraya/items/6f1030279a747bcce648
