### PR TITLE
Routeの作成、更新、削除で認証を必須に

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -398,6 +398,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合

--- a/openapi.yml
+++ b/openapi.yml
@@ -72,6 +72,8 @@ paths:
                     $ref: '#/components/schemas/RouteId'
                 required:
                   - id
+      security:
+        - userBearerAuth: []
   /routes/search:
     get:
       summary: 公開ルートの検索
@@ -261,6 +263,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      security:
+        - userBearerAuth: []
     parameters:
       - in: path
         name: id
@@ -326,6 +330,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      security:
+        - userBearerAuth: []
     parameters:
       - $ref: '#/components/parameters/route_id'
   '/routes/{id}/add/{pos}':
@@ -355,6 +361,8 @@ paths:
                 $ref: '#/components/schemas/Error'
       requestBody:
         $ref: '#/components/requestBodies/RouteEditWithNewPointRequest'
+      security:
+        - userBearerAuth: []
     parameters:
       - $ref: '#/components/parameters/route_id'
       - $ref: '#/components/parameters/pos'
@@ -393,6 +401,8 @@ paths:
                   $ref: '#/components/schemas/DrawingMode'
               required:
                 - mode
+      security:
+        - userBearerAuth: []
     parameters:
       - $ref: '#/components/parameters/route_id'
       - $ref: '#/components/parameters/pos'
@@ -422,6 +432,8 @@ paths:
                 $ref: '#/components/schemas/Error'
       requestBody:
         $ref: '#/components/requestBodies/RouteEditWithNewPointRequest'
+      security:
+        - userBearerAuth: []
     parameters:
       - $ref: '#/components/parameters/route_id'
       - $ref: '#/components/parameters/pos'
@@ -443,6 +455,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      security:
+        - userBearerAuth: []
     parameters:
       - $ref: '#/components/parameters/route_id'
   '/routes/{id}/redo/':
@@ -470,6 +484,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      security:
+        - userBearerAuth: []
     parameters:
       - $ref: '#/components/parameters/route_id'
   '/routes/{id}/undo/':
@@ -497,6 +513,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      security:
+        - userBearerAuth: []
     parameters:
       - $ref: '#/components/parameters/route_id'
   /users/:

--- a/openapi.yml
+++ b/openapi.yml
@@ -72,6 +72,8 @@ paths:
                     $ref: '#/components/schemas/RouteId'
                 required:
                   - id
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
       security:
         - userBearerAuth: []
   /routes/search:
@@ -256,6 +258,10 @@ paths:
       responses:
         '200':
           description: ok
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合
@@ -323,6 +329,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RouteInfo'
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合
@@ -352,6 +362,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合
@@ -423,6 +437,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合
@@ -448,6 +466,10 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/RouteEditResponse'
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合
@@ -477,6 +499,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合
@@ -506,6 +532,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合
@@ -601,12 +631,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-        '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
       operationId: get-user-id
       description: 指定したUserの情報を取得する
       parameters: []
@@ -617,11 +641,9 @@ paths:
         '200':
           description: OK
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: Not Found
           content:
@@ -653,11 +675,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
       description: |-
         email, password以外のUser情報を編集するためのエンドポイント
         認証が必要
@@ -981,6 +1001,25 @@ components:
               - segments
               - elevation_gain
               - total_distance
+    AuthenticationErrorResponse:
+      description: |-
+        認証が必要なのに認証していない場合のエラー
+
+        認証(401)と認可(403)の違い: https://qiita.com/zawawahoge/items/58021f9c0dde1f99b611
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    AuthorizationErrorResponse:
+      description: |-
+        権限などが足りず、認可に失敗した場合のエラー
+        例えば、別のユーザーの非公開Routeにアクセスしようとした場合はこっち
+
+        認証(401)と認可(403)の違い: https://qiita.com/zawawahoge/items/58021f9c0dde1f99b611
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
   examples: {}
   requestBodies:
     RouteEditWithNewPointRequest:


### PR DESCRIPTION
* `Route`作成、更新系、削除のエンドポイントに認証を追加した
* 401と403の区別に気がついたので、そこを整理した
   * 参考： https://qiita.com/zawawahoge/items/58021f9c0dde1f99b611