### PR TITLE
ユーザidが予約ごと被った場合用のエラーコードを追加

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1030,6 +1030,7 @@ components:
       enum:
         - INVALID_FORMAT
         - ALREADY_EXISTS
+        - RESERVED_WORD
   parameters:
     pos:
       name: pos


### PR DESCRIPTION
`ValidationErrorCode`の新たなvariantとして、`RESERVED_WORD`を追加した