### PR TITLE
feat: RouteInfoの中身について要素を追加した

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -920,14 +920,14 @@ components:
           description: ルートの総距離
           minimum: 0
           format: double
-        updated_at:
-          type: string
-          format: date
-          description: 最終更新日時
         created_at:
           type: string
           format: date
           description: 作成日時
+        updated_at:
+          type: string
+          format: date
+          description: 最終更新日時
       required:
         - id
         - name
@@ -935,8 +935,8 @@ components:
         - ascent_elevation_gain
         - descent_elevation_gain
         - total_distance
-        - updated_at
         - created_at
+        - updated_at
     Route:
       type: object
       description: |-

--- a/openapi.yml
+++ b/openapi.yml
@@ -905,10 +905,30 @@ components:
           description: ルートの名前
         owner_id:
           $ref: '#/components/schemas/UserId'
+        elevation_gain:
+          type: integer
+          description: 獲得標高
+          minimum: 0
+          format: int32
+        total_distance:
+          type: number
+          description: ルートの総距離
+          minimum: 0
+          format: double
+        updated_at:
+          type: string
+          title: Birthdate
+          format: date
+          description: 最終更新日時
+        bounding_box:
+          $ref: '#/components/schemas/BoundingBox'
       required:
         - id
         - name
         - owner_id
+        - elevation_gain
+        - total_distance
+        - updated_at
     Route:
       type: object
       description: |-

--- a/openapi.yml
+++ b/openapi.yml
@@ -920,8 +920,6 @@ components:
           title: Birthdate
           format: date
           description: 最終更新日時
-        bounding_box:
-          $ref: '#/components/schemas/BoundingBox'
       required:
         - id
         - name

--- a/openapi.yml
+++ b/openapi.yml
@@ -905,9 +905,14 @@ components:
           description: ルートの名前
         owner_id:
           $ref: '#/components/schemas/UserId'
-        elevation_gain:
+        ascent_elevation_gain:
           type: integer
-          description: 獲得標高
+          description: 上り獲得標高
+          minimum: 0
+          format: int32
+        descent_elevation_gain:
+          type: integer
+          description: 下り獲得標高
           minimum: 0
           format: int32
         total_distance:
@@ -927,7 +932,8 @@ components:
         - id
         - name
         - owner_id
-        - elevation_gain
+        - ascent_elevation_gain
+        - descent_elevation_gain
         - total_distance
         - updated_at
         - created_at

--- a/openapi.yml
+++ b/openapi.yml
@@ -917,9 +917,12 @@ components:
           format: double
         updated_at:
           type: string
-          title: Birthdate
           format: date
           description: 最終更新日時
+        created_at:
+          type: string
+          format: date
+          description: 作成日時
       required:
         - id
         - name
@@ -927,6 +930,7 @@ components:
         - elevation_gain
         - total_distance
         - updated_at
+        - created_at
     Route:
       type: object
       description: |-


### PR DESCRIPTION
## 変更点
- フロントでルート一覧機能を作るにあたり、`GET /routes/search`のレスポンスの値(RouteInfoの配列)のRouteInfoのフィールドに足りないものがあったので、追加をした。追加したのは以下の項目。
  - elevation_gain(required)
  - total_distance(required)
  - updated_at(required)
  - bounding_box 