### PR TITLE
編集可能なルートに絞った検索

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -631,10 +631,12 @@ paths:
             schema:
               type: object
               properties:
-                　user_id:
+                user_id:
                   $ref: '#/components/schemas/UserId'
               required:
-                - 　user_id
+                - user_id
+      tags:
+        - route
   /users/:
     post:
       summary: Userの作成
@@ -848,6 +850,8 @@ paths:
                     $ref: '#/components/schemas/ValidationErrorCode'
                   password:
                     $ref: '#/components/schemas/ValidationErrorCode'
+      tags:
+        - user
 components:
   schemas:
     Coordinate:

--- a/openapi.yml
+++ b/openapi.yml
@@ -991,6 +991,11 @@ components:
           description: ルートの総距離
           minimum: 0
           format: double
+        is_public:
+          type: boolean
+          description: |-
+            公開ルートか否か
+            公開の場合、前ユーザがVIEWER権限を持つことと等価である
         created_at:
           type: string
           format: date
@@ -1006,6 +1011,7 @@ components:
         - ascent_elevation_gain
         - descent_elevation_gain
         - total_distance
+        - is_public
         - created_at
         - updated_at
     Route:

--- a/openapi.yml
+++ b/openapi.yml
@@ -137,6 +137,12 @@ paths:
           in: query
           name: page_size
           description: ページあたりの検索結果件数 （指定されなかった場合、全件取得する）
+        - schema:
+            type: boolean
+            default: 'false'
+          in: query
+          name: is_editable
+          description: falseの場合、閲覧可能な`Route`から検索する。trueの場合、リクエストしたユーザが編集可能な`Route`のみ抽出して返す。
       security:
         - {}
         - userBearerAuth: []
@@ -288,7 +294,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
       security:
-        - {} 
+        - {}
         - userBearerAuth: []
     delete:
       operationId: routesDelete

--- a/openapi.yml
+++ b/openapi.yml
@@ -568,6 +568,37 @@ paths:
         - userBearerAuth: []
     parameters:
       - $ref: '#/components/parameters/route_id'
+  '/routes/{id}/permissions/':
+    parameters:
+      - $ref: '#/components/parameters/route_id'
+    put:
+      summary: あるユーザへの権限の付与
+      operationId: put-routes-id-permissions
+      responses:
+        '200':
+          description: OK
+        '401':
+          $ref: '#/components/responses/AuthenticationErrorResponse'
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
+      tags:
+        - route
+      security:
+        - userBearerAuth: []
+      description: |-
+        bodyで指定した`User`に指定した`PermissionType`の権限を付与する。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
+    delete:
+      summary: 権限の削除
+      operationId: delete-routes-id-permissions
+      responses:
+        '200':
+          description: OK
+      description: |-
+        bodyで指定した`User`の権限を削除する。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
+      security:
+        - userBearerAuth: []
   /users/:
     post:
       summary: Userの作成
@@ -955,6 +986,19 @@ components:
         - segments
         - elevation_gain
         - total_distance
+    PermissionType:
+      type: string
+      title: PermissionType
+      description: |-
+        リソースへの権限の種類
+        権限の強さは
+        VIEWER < EDITOR (< OWNER)
+        OWNERはこの値ではなく、`RouteInfo`の`owner_id`から取得する
+      enum:
+        - VIEWER
+        - EDITOR
+      x-tags:
+        - route
     User:
       title: User
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -599,7 +599,7 @@ paths:
         - userBearerAuth: []
       description: |-
         bodyで指定した`User`に指定した`PermissionType`の権限を付与する。
-        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
+        このエンドポイントを呼ぶには、`OWNER`権限が必要。
       requestBody:
         content:
           application/json:
@@ -622,7 +622,7 @@ paths:
       description: |-
         bodyで指定した`User`の権限を削除する。
         指定した`User`が権限を持っていなかったとしても、エラーとはならない。
-        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
+        このエンドポイントを呼ぶには、`OWNER`権限が必要。
       security:
         - userBearerAuth: []
       requestBody:

--- a/openapi.yml
+++ b/openapi.yml
@@ -600,6 +600,19 @@ paths:
       description: |-
         bodyで指定した`User`に指定した`PermissionType`の権限を付与する。
         このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  $ref: '#/components/schemas/UserId'
+                type:
+                  $ref: '#/components/schemas/PermissionType'
+              required:
+                - user_id
+                - type
     delete:
       summary: 権限の削除
       operationId: delete-routes-id-permissions
@@ -608,9 +621,20 @@ paths:
           description: OK
       description: |-
         bodyで指定した`User`の権限を削除する。
+        指定した`User`が権限を持っていなかったとしても、エラーとはならない。
         このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
       security:
         - userBearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                　user_id:
+                  $ref: '#/components/schemas/UserId'
+              required:
+                - 　user_id
   /users/:
     post:
       summary: Userの作成

--- a/openapi.yml
+++ b/openapi.yml
@@ -36,7 +36,15 @@ paths:
                         owner_id: user0
                 required:
                   - routes
-      description: 全`Route`の`RouteInfo`を一覧で返す
+      description: |-
+        全公開`Route`の`RouteInfo`を一覧で返す
+        Bearerトークンを指定した場合は、公開ルートに加えてそのユーザがVIEWER権限を持つ`Route`が返される
+
+        `/routes/search`で代用可能なのでdeprecatred
+      security:
+        - {}
+        - userBearerAuth: []
+      deprecated: true
     post:
       operationId: routesPost
       summary: Routeの作成
@@ -103,6 +111,11 @@ paths:
       description: |-
         公開ルートの検索を行う。
         現状は`updated_at`の昇順で返ってくる（いずれ作成日時などのフィールドを追加して、それに応じて並べたい）
+
+        Bearerトークンを指定した場合は、公開ルートに加えてそのユーザがVIEWER権限を持つ`Route`が返される
+
+        OpenAPI Specのsecurityの部分は、BearerAuthを指定しても指定しなくても良いということを表している
+        参考：https://github.com/OAI/OpenAPI-Specification/issues/14#issuecomment-551495541
       parameters:
         - schema:
             type: string
@@ -124,6 +137,9 @@ paths:
           in: query
           name: page_size
           description: ページあたりの検索結果件数 （指定されなかった場合、全件取得する）
+      security:
+        - {}
+        - userBearerAuth: []
     parameters: []
   '/routes/{id}':
     get:
@@ -133,7 +149,8 @@ paths:
         - route
       description: |
         指定したRouteの情報を取得する。
-        このエンドポイントを呼ぶには、`VIEWER`以上の権限が必要。
+
+        `Route`が公開されている場合は、認証なしで誰でも呼ぶことができるが、非公開の場合、このエンドポイントを呼ぶにはBearerトークンを指定した上で、`VIEWER`以上の権限が必要。
       responses:
         '200':
           description: ok
@@ -261,6 +278,8 @@ paths:
                   max_coord:
                     longitude: 139.76143
                     latitude: 35.69055
+        '403':
+          $ref: '#/components/responses/AuthorizationErrorResponse'
         '404':
           description: |
             対応するRouteが存在しない場合
@@ -268,6 +287,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+      security:
+        - {} 
+        - userBearerAuth: []
     delete:
       operationId: routesDelete
       summary: Routeの削除

--- a/openapi.yml
+++ b/openapi.yml
@@ -132,7 +132,8 @@ paths:
       tags:
         - route
       description: |
-        指定したRouteの情報を取得する
+        指定したRouteの情報を取得する。
+        このエンドポイントを呼ぶには、`VIEWER`以上の権限が必要。
       responses:
         '200':
           description: ok
@@ -288,6 +289,9 @@ paths:
                 $ref: '#/components/schemas/Error'
       security:
         - userBearerAuth: []
+      description: |-
+        指定した`Route`を削除する
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
     parameters:
       - in: path
         name: id
@@ -316,14 +320,15 @@ paths:
                 type: object
                 properties: {}
       operationId: get-routes-id-gpx
-      description: ''
+      description: このエンドポイントを呼ぶには、`VIEWER`以上の権限が必要。
       parameters: []
   '/routes/{id}/rename/':
     patch:
       operationId: routesRename
       summary: Routeの名前変更
       description: |
-        指定したRouteの名前を変更する
+        指定したRouteの名前を変更する。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
       tags:
         - route
       requestBody:
@@ -368,7 +373,8 @@ paths:
       tags:
         - route
       description: |
-        指定したRouteのpos番目の位置に新たな点を追加する
+        指定したRouteのpos番目の位置に新たな点を追加する。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
       responses:
         '200':
           $ref: '#/components/responses/RouteEditResponse'
@@ -404,7 +410,8 @@ paths:
       tags:
         - route
       description: |
-        指定したRouteのpos番目の点を削除する
+        指定したRouteのpos番目の点を削除する。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
       responses:
         '200':
           $ref: '#/components/responses/RouteEditResponse'
@@ -445,7 +452,9 @@ paths:
     patch:
       operationId: routesMove
       summary: 点の座標の変更
-      description: route_idに対応するRouteのpos番目の点の座標を変更する
+      description: |-
+        route_idに対応するRouteのpos番目の点の座標を変更する。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
       tags:
         - route
       responses:
@@ -483,7 +492,8 @@ paths:
       tags:
         - route
       description: |
-        指定したRouteの全ての点を削除する
+        指定したRouteの全ての点を削除する。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
       responses:
         '200':
           $ref: '#/components/responses/RouteEditResponse'
@@ -509,7 +519,8 @@ paths:
       tags:
         - route
       description: |
-        指定したRouteの操作を一つ進める
+        指定したRouteの操作を一つ進める。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
       responses:
         '200':
           $ref: '#/components/responses/RouteEditResponse'
@@ -542,7 +553,8 @@ paths:
       tags:
         - route
       description: |
-        指定したRouteの操作を一つ戻す
+        指定したRouteの操作を一つ戻す。
+        このエンドポイントを呼ぶには、`EDITOR`以上の権限が必要。
       responses:
         '200':
           $ref: '#/components/responses/RouteEditResponse'


### PR DESCRIPTION
`GET /routes/search`のリクエストパラメータに`is_editable`を追加し、これをtrueにした場合、編集可能なルートの中から検索を行うようにした。